### PR TITLE
Added ability to pass constant values, maps, and lists to concordion fix...

### DIFF
--- a/src/main/java/org/concordion/internal/SimpleEvaluator.java
+++ b/src/main/java/org/concordion/internal/SimpleEvaluator.java
@@ -21,12 +21,20 @@ public class SimpleEvaluator extends OgnlEvaluator {
         super.setVariable(expression, value);
     }
 
+    
     private static String METHOD_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
     private static String PROPERTY_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
     private static String STRING_PATTERN = "'[^']+'";
     private static String LHS_VARIABLE_PATTERN = "#" + METHOD_NAME_PATTERN;
-    private static String RHS_VARIABLE_PATTERN = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF)";
+
+
+    private static String RHS_VARIABLE_PATTERN_NO_MAP = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF|'.*')" ;
+    private static String LIST_PATTERN = "\\{ *" + RHS_VARIABLE_PATTERN_NO_MAP + "( *, *" + RHS_VARIABLE_PATTERN_NO_MAP + " *)\\}";
+    private static String MAP_VALUE_PATTERN = RHS_VARIABLE_PATTERN_NO_MAP + " *\\: *" + RHS_VARIABLE_PATTERN_NO_MAP;
+    private static String MAP_PATTERN = "#\\{ *" + MAP_VALUE_PATTERN + "( *, *" + MAP_VALUE_PATTERN + " *)*\\}";
+    private static String RHS_VARIABLE_PATTERN = "(" + RHS_VARIABLE_PATTERN_NO_MAP + "|" + MAP_PATTERN + "|" + LIST_PATTERN + ")" ;
     
+   
     public static void validateEvaluationExpression(String expression) {
         
         // Examples of possible expressions in test.concordion.internal.ExpressionTest
@@ -57,6 +65,7 @@ public class SimpleEvaluator extends OgnlEvaluator {
                 return;
             }
         }
+        System.err.println("Invalid expression: " + expression);
         throw new RuntimeException("Invalid expression [" + expression + "]");
     }
 

--- a/src/test/java/spec/concordion/command/execute/ExecuteTest.java
+++ b/src/test/java/spec/concordion/command/execute/ExecuteTest.java
@@ -1,5 +1,10 @@
 package spec.concordion.command.execute;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.concordion.integration.junit3.ConcordionTestCase;
 
 import test.concordion.TestRig;
@@ -7,15 +12,61 @@ import test.concordion.TestRig;
 public class ExecuteTest extends ConcordionTestCase {
 
     private boolean myMethodWasCalled = false;
+	private String argument = null;
     
     public boolean myMethodWasCalledProcessing(String fragment) {
+    	myMethodWasCalled = false;
+    	argument = null;
         new TestRig()
             .withFixture(this)
             .processFragment(fragment);
         return myMethodWasCalled;
     }
     
+    public String getArgument() {
+    	return argument;
+    }
+    
     public void myMethod() {
+    	argument = "none";
         myMethodWasCalled = true;
     }
+    
+    public void myMethod(String arg) {
+        myMethodWasCalled = true; 	
+        argument = arg;
+    }
+    
+    public void myMethod(Map<String, String> arg) {
+        myMethodWasCalled = true; 	
+        
+        StringBuilder args = new StringBuilder();
+        
+        Set<String> keys  = arg.keySet();
+        Set<String> orderedKeys = new TreeSet<String>(keys);
+        
+        args.append("{");
+        for (String key: orderedKeys) {
+        	args.append("(").append(key).append(":").append(arg.get(key)).append(")");
+        }
+        args.append("}");
+        
+        argument = args.toString();
+    }
+    
+    public void myMethod(List<String> arg) {
+        myMethodWasCalled = true; 	
+        
+        
+        StringBuilder args= new StringBuilder();
+        
+        args.append("[");
+        for (String item: arg) {
+        	args.append("(").append(item).append(")");
+        }
+        args.append("]");
+        
+        argument = args.toString();
+    }
+
 }

--- a/src/test/resources/spec/concordion/command/execute/Execute.html
+++ b/src/test/resources/spec/concordion/command/execute/Execute.html
@@ -14,7 +14,7 @@
     
     <div class="example">
 
-        <h3>Example</h3>
+        <h3>Example - no argument</h3>
         
         <p>The following instrumentation:</p>
 <pre class="html" concordion:set="#fragment">
@@ -26,6 +26,52 @@
         </p> 
         
     </div>            
+
+   <div class="example">
+
+        <h3>Example - single static argument</h3>
+        
+        <p>The following instrumentation:</p>
+<pre class="html" concordion:set="#fragment">
+&lt;p concordion:execute="myMethod('arg')"&gt;Some text goes here.&lt;/p&gt;
+</pre>
+        <p>
+            <span concordion:assertEquals="myMethodWasCalledProcessing(#fragment) ? 'Will' : 'Will not'">Will</span>
+            call <code>myMethod('arg')</code> in the Java fixture code with argument <span concordion:assertEquals="getArgument()">arg</span>.
+        </p> 
+        
+    </div>            
+
+
+   <div class="example">
+
+        <h3>Example - map as argument</h3>
+        
+        <p>The following instrumentation:</p>
+<pre class="html" concordion:set="#fragment">
+&lt;p concordion:execute="myMethod(#{'arg':'value', 'arg2': 'value2'})"&gt;Some text goes here.&lt;/p&gt;
+</pre>
+        <p>
+            <span concordion:assertEquals="myMethodWasCalledProcessing(#fragment) ? 'Will' : 'Will not'">Will</span>
+            call <code>myMethod(#{ 'arg': 'value', 'arg2': 'value2'})</code> in the Java fixture code with argument <span concordion:assertEquals="getArgument()">{(arg:value)(arg2:value2)}</span>.
+        </p> 
+        
+    </div>            
+
+<div class="example">
+
+        <h3>Example - list as argument</h3>
+        
+        <p>The following instrumentation:</p>
+<pre class="html" concordion:set="#fragment">
+&lt;p concordion:execute="myMethod({'arg', 'value','arg2','value2'})"&gt;Some text goes here.&lt;/p&gt;
+</pre>
+        <p>
+            <span concordion:assertEquals="myMethodWasCalledProcessing(#fragment) ? 'Will' : 'Will not'">Will</span>
+            call <code>myMethod({'arg', 'value','arg2','value2'})</code> in the Java fixture code with argument <span concordion:assertEquals="getArgument()">[(arg)(value)(arg2)(value2)]</span>.
+        </p> 
+        
+    </div>     
 
     <h2>Further Details</h2>
 


### PR DESCRIPTION
Added ability to call concordion:execute with additional types of parameters:
- constants. ie: doSomething('const')
- maps. ie: doSomething(#{'hi': 'there', 'hello':'bob'})
- lists. ie: doSomething({'hi', 'there'})
