### PR TITLE
*Scoped annotations - refactored conditional statement to annotation

### DIFF
--- a/src/main/java/org/concordion/api/ExampleScoped.java
+++ b/src/main/java/org/concordion/api/ExampleScoped.java
@@ -5,8 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.concordion.internal.ConcordionScopeDeclaration;
+import org.concordion.internal.ConcordionScopedField;
+
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
+@ConcordionScopeDeclaration(scope = ConcordionScopedField.Scope.EXAMPLE)
 public @interface ExampleScoped {
     String value() default "";
 }

--- a/src/main/java/org/concordion/api/GloballyScoped.java
+++ b/src/main/java/org/concordion/api/GloballyScoped.java
@@ -5,8 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.concordion.internal.ConcordionScopeDeclaration;
+import org.concordion.internal.ConcordionScopedField;
+
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
+@ConcordionScopeDeclaration(scope = ConcordionScopedField.Scope.GLOBAL)
 public @interface GloballyScoped {
     String value() default "";
 }

--- a/src/main/java/org/concordion/api/SpecificationScoped.java
+++ b/src/main/java/org/concordion/api/SpecificationScoped.java
@@ -5,8 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.concordion.internal.ConcordionScopeDeclaration;
+import org.concordion.internal.ConcordionScopedField;
+
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
+@ConcordionScopeDeclaration(scope = ConcordionScopedField.Scope.SPECIFICATION)
 public @interface SpecificationScoped {
     String value() default "";
 }

--- a/src/main/java/org/concordion/internal/ConcordionScopeDeclaration.java
+++ b/src/main/java/org/concordion/internal/ConcordionScopeDeclaration.java
@@ -1,0 +1,14 @@
+package org.concordion.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.concordion.internal.ConcordionScopedField.Scope;
+
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConcordionScopeDeclaration {
+    Scope scope();
+}

--- a/src/main/java/org/concordion/internal/ConcordionScopedField.java
+++ b/src/main/java/org/concordion/internal/ConcordionScopedField.java
@@ -1,4 +1,4 @@
-package org.concordion.api;
+package org.concordion.internal;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectImpl.java
+++ b/src/main/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectImpl.java
@@ -1,6 +1,6 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
+import org.concordion.internal.ConcordionScopedField;
 
 /**
  * Created by tim on 3/12/15.

--- a/src/main/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectRepository.java
+++ b/src/main/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectRepository.java
@@ -1,6 +1,6 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
+import org.concordion.internal.ConcordionScopedField;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/org/concordion/internal/scopedObjects/ScopedObjectRepositoryKey.java
+++ b/src/main/java/org/concordion/internal/scopedObjects/ScopedObjectRepositoryKey.java
@@ -1,6 +1,6 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
+import org.concordion.internal.ConcordionScopedField;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectFactoryTest.java
+++ b/src/test/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectFactoryTest.java
@@ -1,7 +1,7 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
 import org.concordion.api.Fixture;
+import org.concordion.internal.ConcordionScopedField;
 import org.concordion.internal.scopedObjects.ConcordionScopedObject;
 import org.concordion.internal.scopedObjects.ConcordionScopedObjectFactory;
 import org.junit.Before;

--- a/src/test/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectImplTest.java
+++ b/src/test/java/org/concordion/internal/scopedObjects/ConcordionScopedObjectImplTest.java
@@ -1,6 +1,6 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
+import org.concordion.internal.ConcordionScopedField;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/src/test/java/org/concordion/internal/scopedObjects/ScopedAnnotationsTest.java
+++ b/src/test/java/org/concordion/internal/scopedObjects/ScopedAnnotationsTest.java
@@ -1,6 +1,7 @@
 package org.concordion.internal.scopedObjects;
 
 import org.concordion.api.*;
+import org.concordion.internal.ConcordionScopedField;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/concordion/internal/scopedObjects/ScopedObjectRepositoryKeyTest.java
+++ b/src/test/java/org/concordion/internal/scopedObjects/ScopedObjectRepositoryKeyTest.java
@@ -1,6 +1,6 @@
 package org.concordion.internal.scopedObjects;
 
-import org.concordion.api.ConcordionScopedField;
+import org.concordion.internal.ConcordionScopedField;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/src/test/java/spec/concordion/command/example/ConcordionScopedFieldFixture.java
+++ b/src/test/java/spec/concordion/command/example/ConcordionScopedFieldFixture.java
@@ -1,7 +1,7 @@
 package spec.concordion.command.example;
 
-import org.concordion.api.ConcordionScopedField;
 import org.concordion.integration.junit4.ConcordionRunner;
+import org.concordion.internal.ConcordionScopedField;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.atomic.AtomicInteger;


### PR DESCRIPTION
Added new annotation ConcordionScopeDeclaration to the ExampleScoped, GloballyScoped and SpecificationScoped annotations, so that the scope is defined in the annotation rather than in a conditional statement.

Moved ConcordionScopedField to internal - is this annotation even serving a purpose now, other than holding the enum of Scopes? How about we make Scope a top level enum and remove ConcordionScopedField?