### PR TITLE
Fix Example Listener Test.

### DIFF
--- a/src/test/java/spec/concordion/extension/listener/ExampleListenerTest.java
+++ b/src/test/java/spec/concordion/extension/listener/ExampleListenerTest.java
@@ -1,5 +1,7 @@
 package spec.concordion.extension.listener;
 
+import java.util.List;
+
 import org.concordion.api.BeforeSpecification;
 import org.concordion.api.extension.Extension;
 import org.concordion.integration.junit4.ConcordionRunner;
@@ -19,11 +21,13 @@ public class ExampleListenerTest extends AbstractExtensionTestCase {
         extension.withStream(getLogStream());
     }
 	
-//    public void addExampleExtension() {
-//        setExtension(new ExampleTestExtension().withStream(getLogStream()));
-//    }
-        
     public double sqrt(double num) {
         return Math.sqrt(num);
+    }
+    
+    public List<String> getEventLogExcludingCheck() {
+        List<String> eventLog = getEventLog();
+        eventLog.remove("Before example 'check-results'");
+        return eventLog;
     }
 }

--- a/src/test/resources/spec/concordion/extension/listener/ExampleListener.html
+++ b/src/test/resources/spec/concordion/extension/listener/ExampleListener.html
@@ -23,13 +23,14 @@
 			</p>
 		</div>
 	
-        <p>The logged events for this example are:</p>
-        <table concordion:verifyRows="#event : getEventLog()">
-        <tr><th concordion:assertEquals="#event">Event</th></tr>
-        <tr><td>Before example 'example1'</td></tr>
-        <tr><td>After example 'example1' - passed: 1, failed: 0, exceptions: 0</td></tr>
-        </table>
- 
+        <div concordion:example="check-results">
+           <p>The logged events for this example are:</p>
+           <table concordion:verifyRows="#event : getEventLogExcludingCheck()">
+           <tr><th concordion:assertEquals="#event">Event</th></tr>
+           <tr><td>Before example 'example1'</td></tr>
+           <tr><td>After example 'example1' - passed: 1, failed: 0, exceptions: 0</td></tr>
+           </table>
+        </div> 
     </div>
 </body>
 </html>


### PR DESCRIPTION
The test was relying on the outer example being executed last. Now works with the outer example either first or last.
However it now depends on the examples being run in order from top to bottom, which is not guaranteed